### PR TITLE
make header and footer not fixed

### DIFF
--- a/assets/stylesheets/core.css
+++ b/assets/stylesheets/core.css
@@ -140,12 +140,8 @@ body {
 @media (min-width: 768px) {
   /* Pull out the header and footer */
   .masthead {
-    position: fixed;
-    top: 0;
   }
   .mastfoot {
-    position: fixed;
-    bottom: 0;
   }
   /* Start the vertical centering */
   .site-wrapper-inner {


### PR DESCRIPTION
before:
<img width="1257" alt="Screen Shot 2019-03-12 at 3 21 42 PM" src="https://user-images.githubusercontent.com/18632342/54240184-91221500-44da-11e9-98c7-0c95e1509d36.png">

after:
<img width="1257" alt="Screen Shot 2019-03-12 at 3 22 06 PM" src="https://user-images.githubusercontent.com/18632342/54240197-9d0dd700-44da-11e9-86af-4cc84243f8d9.png">
